### PR TITLE
Add runtime index number for pallets in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,13 +157,13 @@ fn testnet_genesis(initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>,
 				.map(|k| (k, 1 << 60))
 				.collect(),
 		},
-		validator_set: ValidatorSetConfig {
+		validatorset: ValidatorSetConfig {
 			validators: initial_authorities
 				.iter()
 				.map(|x| x.0.clone())
 				.collect::<Vec<_>>(),
 		},
-		session: SessionConfig {
+		pallet_session: SessionConfig {
 			keys: initial_authorities
 				.iter()
 				.map(|x| {

--- a/readme.md
+++ b/readme.md
@@ -112,9 +112,10 @@ construct_runtime!(
 > Alternatively, you can use give your pallets an explicit order by index in for your runtime, as
 > illustrated in
 > [Polkadot's runtime](https://github.com/paritytech/polkadot/blob/4767814e3d6eb8f95f2673dbe3802034d0858124/runtime/polkadot/src/lib.rs#L997-L1005)
-> to ensure any runtime upgrades retain the ordering of pallets enforced by the `construct_runtime!`
-> macro by index, not by line ordering. The index must be _less than_ `Aura` and `Grandpa` and
-> _greater than_ `Balances`.
+> to ensure any runtime upgrades retain the ordering by index of pallets configured by the
+> `construct_runtime!` macro, ignoring line ordering.
+>
+> The index must be _less than_ `Aura` and `Grandpa` and _greater than_ `Balances`.
 >
 > ```rust
 > construct_runtime!(


### PR DESCRIPTION
- Suggested addition in case that ordering, as implied, is critical to proper function of these pallets. 

- IDE decided to format to 100 char max lines (soft limit) here too.

- `cargo fmt -- --config hard_tabs=true` used for examples snippets (as this is used on the template now) 

---

> Alternatively, you can use give your pallets an explicit order by index in for your runtime, as
> illustrated in [Polkadot's runtime](https://github.com/paritytech/polkadot/blob/4767814e3d6eb8f95f2673dbe3802034d0858124/runtime/polkadot/src/lib.rs#L997-L1005) to ensure any runtime upgrades retain the ordering of pallets enforced by the `construct_runtime!` macro by index, not by line ordering.
>
> The index must be _less than_ `Aura` and `Grandpa` and _greater than_ `Balances`.
>
> ```rust
> construct_runtime!(
> 	pub enum Runtime where
> 		Block = Block,
> 		NodeBlock = opaque::Block,
> 		UncheckedExtrinsic = UncheckedExtrinsic
> 	{
> 		...
> 		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>} = 3,
> 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 4,
> 		ValidatorSet: validatorset::{Pallet, Call, Storage, Event<T>, Config<T>} = 5,
> 		Aura: pallet_aura::{Module, Config<T>} = 6,
> 		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event} = 7,
> 		...
> 		...
> 	}
> );
> ```