### PR TITLE
Frontier to use `67f28cd` for substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'substrate-validator-set'
-version = '3.0.1'
+version = '4.0.0-dev'
 authors = ['Gautam Dhameja <quasijatt@outlook.com>']
 edition = '2018'
 license = 'Apache-2.0'
@@ -8,31 +8,31 @@ repository = 'https://github.com/gautamdhameja/substrate-validator-set'
 
 [dev-dependencies.serde]
 features = ['derive']
-version = '1.0.119'
+version = '1.0.126'
 
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.codec]
 default-features = false
@@ -44,26 +44,26 @@ version = '2.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-tag = 'monthly-2021-07'
-version = '3.1.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+tag = 'monthly-2021-08'
+version = '4.0.0-dev'
 
 [features]
 default = ['std']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,25 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.codec]
@@ -44,25 +44,25 @@ version = '2.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,26 +13,18 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.codec]
 default-features = false
@@ -44,26 +36,18 @@ version = '2.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
-version = '4.0.0-dev'
 
 [features]
 default = ['std']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,25 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.codec]
@@ -44,25 +44,25 @@ version = '2.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7'
 version = '4.0.0-dev'
 
 [features]

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,14 @@
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators
 using extrinsics, in Substrate-based PoA networks.
 
-**Note: The current `frontier` branch in this repo is compatible with
+**Note:** The current `frontier` branch in this repo is compatible with
 [Frontier master `0b962f21`](https://github.com/paritytech/frontier/commit/0b962f218f0cdd796dadfe26c3f09e68f7861b26)
 using
-[Substrate master `67f28cd`](https://github.com/paritytech/substrate/commit/67f28cdba85c362da17909c69c19952e3ef931c7). 
+[Substrate master `67f28cd`](https://github.com/paritytech/substrate/commit/67f28cdba85c362da17909c69c19952e3ef931c7).
+
+For compatability with updates upstream, you will need to manually update your project's `Cargo.lock` to use the
+correct commit from Substrate that Frontier uses. All substrate dependancies should point to the _same commit_.
+
 
 ## Demo
 

--- a/readme.md
+++ b/readme.md
@@ -1,31 +1,39 @@
 # Substrate Validator Set Pallet
 
-A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators using extrinsics, in Substrate-based PoA networks.
+A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators
+using extrinsics, in Substrate-based PoA networks.
 
-**Note: Current master is compatible with Substrate [monthly-2021-09+1](https://github.com/paritytech/substrate/releases/tag/monthly-2021-09+1) tag. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate
+[monthly-2021-09+1](https://github.com/paritytech/substrate/releases/tag/monthly-2021-09+1) tag. For
+older versions, please see releases/tags.**
 
 ## Demo
 
-To see this pallet in action in a Substrate runtime, watch this video - https://www.youtube.com/watch?v=lIYxE-tOAdw
+To see this pallet in action in a Substrate runtime, watch this video -
+https://www.youtube.com/watch?v=lIYxE-tOAdw
 
 ## Setup with Substrate Node Template
 
-* Add the module's dependency in the `Cargo.toml` of your runtime directory. Make sure to enter the correct path or git url of the pallet as per your setup.
+-   Add the module's dependency in the `Cargo.toml` of your runtime directory. Make sure to enter
+    the correct path or git url of the pallet as per your setup.
 
-* Make sure that you also have the Substrate [session pallet](https://github.com/paritytech/substrate/tree/master/frame/session) as part of your runtime. This is because the validator-set pallet is dependent on the session pallet.
+-   Make sure that you also have the Substrate
+    [session pallet](https://github.com/paritytech/substrate/tree/master/frame/session) as part of
+    your runtime. This is because the validator-set pallet is dependent on the session pallet.
 
 ```toml
 [dependencies.validatorset]
-default-features = false
 package = 'substrate-validator-set'
+default-features = false
+version = '4.0.0-dev'
 git = 'https://github.com/gautamdhameja/substrate-validator-set.git'
-version = '3.0.1'
+branch = 'frontier'
 
 [dependencies.pallet-session]
 default-features = false
+version = '4.0.0-dev'
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-07'
-version = '3.0.0'
+rev = '67f28cdba85c362da17909c69c19952e3ef931c7' # for use with frontier rev = '0b962f218f0cdd796dadfe26c3f09e68f7861b26'
 ```
 
 ```toml
@@ -36,7 +44,7 @@ std = [
 ]
 ```
 
-* Import `OpaqueKeys` in your `runtime/src/lib.rs`.
+-   Import `OpaqueKeys` in your `runtime/src/lib.rs`.
 
 ```rust
 use sp_runtime::traits::{
@@ -44,13 +52,17 @@ use sp_runtime::traits::{
 };
 ```
 
-* Also in `runtime/src/lib.rs` import the `EnsureRoot` trait. This would change if you want to configure a custom origin (see below).
+-   Also in `runtime/src/lib.rs` import the `EnsureRoot` trait. This would change if you want to
+    configure a custom origin (see below).
 
 ```rust
 	use frame_system::EnsureRoot;
 ```
 
-* Declare the pallet in your `runtime/src/lib.rs`. The pallet supports configurable origin and you can eiher set it to use one of the governance pallets (Collective, Democracy, etc.), or just use root as shown below. But **do not use a normal origin here** because the addition and removal of validators should be done using elevated privileges.
+-   Declare the pallet in your `runtime/src/lib.rs`. The pallet supports configurable origin and you
+    can eiher set it to use one of the governance pallets (Collective, Democracy, etc.), or just use
+    root as shown below. But **do not use a normal origin here** because the addition and removal of
+    validators should be done using elevated privileges.
 
 ```rust
 impl validatorset::Config for Runtime {
@@ -59,7 +71,8 @@ impl validatorset::Config for Runtime {
 }
 ```
 
-* Also, declare the session pallet in  your `runtime/src/lib.rs`. The type configuration of session pallet would depend on the ValidatorSet pallet as shown below.
+-   Also, declare the session pallet in your `runtime/src/lib.rs`. The type configuration of session
+    pallet would depend on the ValidatorSet pallet as shown below.
 
 ```rust
 impl pallet_session::Config for Runtime {
@@ -76,7 +89,8 @@ impl pallet_session::Config for Runtime {
 }
 ```
 
-* Add both `session` and `validatorset` pallets in `construct_runtime` macro. **Make sure to add them before `Aura` and `Grandpa` pallets and after `Balances`.**
+-   Add both `session` and `validatorset` pallets in `construct_runtime` macro. **Make sure to add
+    them before `Aura` and `Grandpa` pallets and after `Balances`.**
 
 ```rust
 construct_runtime!(
@@ -97,7 +111,11 @@ construct_runtime!(
 );
 ```
 
-* Add genesis config in the `chain_spec.rs` file for `session` and `validatorset` pallets, and update it for `Aura` and `Grandpa` pallets. Because the validators are provided by the `session` pallet, we do not initialize them explicitly for `Aura` and `Grandpa` pallets. Order is important, notice that `pallet_session` is declared after `pallet_balances` since it depends on it (session accounts should have some balance).
+-   Add genesis config in the `chain_spec.rs` file for `session` and `validatorset` pallets, and
+    update it for `Aura` and `Grandpa` pallets. Because the validators are provided by the `session`
+    pallet, we do not initialize them explicitly for `Aura` and `Grandpa` pallets. Order is
+    important, notice that `pallet_session` is declared after `pallet_balances` since it depends on
+    it (session accounts should have some balance).
 
 ```rust
 fn testnet_genesis(initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>,
@@ -127,7 +145,8 @@ fn testnet_genesis(initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>,
 }
 ```
 
-* Make sure you have the same number and order of session keys for your runtime. First in `runtime/src/lib.rs`:
+-   Make sure you have the same number and order of session keys for your runtime. First in
+    `runtime/src/lib.rs`:
 
 ```rust
 pub struct SessionKeys {
@@ -136,7 +155,7 @@ pub struct SessionKeys {
 }
 ```
 
-* And then in `node/src/chain_spec.rs`:
+-   And then in `node/src/chain_spec.rs`:
 
 ```rust
 fn session_keys(
@@ -159,30 +178,34 @@ pub fn authority_keys_from_seed(s: &str) -> (
 }
 ```
 
-* Import `opaque::SessionKeys, ValidatorSetConfig, SessionConfig` from the runtime in `node/src/chain_spec.rs`.
-  
+-   Import `opaque::SessionKeys, ValidatorSetConfig, SessionConfig` from the runtime in
+    `node/src/chain_spec.rs`.
+
 ```rust
 use node_template_runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, SystemConfig, WASM_BINARY, Signature, 
+	SudoConfig, SystemConfig, WASM_BINARY, Signature,
 	opaque::SessionKeys, ValidatorSetConfig, SessionConfig
 };
 ```
 
 ## Run
 
-Once you have set up the pallet in your node/node-template and everything compiles, watch this video to see how to run the chain and add validators - https://www.youtube.com/watch?v=lIYxE-tOAdw.
+Once you have set up the pallet in your node/node-template and everything compiles, watch this video
+to see how to run the chain and add validators - https://www.youtube.com/watch?v=lIYxE-tOAdw.
 
-To use the pallet with the `Collective` pallet, follow the steps in [docs/council-integration.md](./docs/council-integration.md).
+To use the pallet with the `Collective` pallet, follow the steps in
+[docs/council-integration.md](./docs/council-integration.md).
 
 ## Types for Polkadot JS Apps/API
 
 ```json
 {
-  "Keys": "SessionKeys2"
+	"Keys": "SessionKeys2"
 }
 ```
 
 ## Disclaimer
 
-This code not audited and reviewed for production use cases. You can expect bugs and security vulnerabilities. Do not use it as-is in real applications.
+This code not audited and reviewed for production use cases. You can expect bugs and security
+vulnerabilities. Do not use it as-is in real applications.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators using extrinsics, in Substrate-based PoA networks.
 
-**Note: Current build is compatible with Substrate [monthly-2021-07](https://github.com/paritytech/substrate/releases/tag/monthly-2021-07) tag.**
+**Note: Current master is compatible with Substrate [monthly-2021-08](https://github.com/paritytech/substrate/releases/tag/monthly-2021-08) tag. For older versions, please see releases/tags.**
 
 ## Demo
 
@@ -160,6 +160,7 @@ pub fn authority_keys_from_seed(s: &str) -> (
 ```
 
 * Import `opaque::SessionKeys, ValidatorSetConfig, SessionConfig` from the runtime in `node/src/chain_spec.rs`.
+  
 ```rust
 use node_template_runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators using extrinsics, in Substrate-based PoA networks.
 
-**Note: Current master is compatible with Substrate [monthly-2021-08](https://github.com/paritytech/substrate/releases/tag/monthly-2021-08) tag. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate [monthly-2021-09+1](https://github.com/paritytech/substrate/releases/tag/monthly-2021-09+1) tag. For older versions, please see releases/tags.**
 
 ## Demo
 


### PR DESCRIPTION
I use the lock file in frontier based projects using this to set:
frontier `0b962f218f0cdd796dadfe26c3f09e68f7861b26`
that itself locks to substrate `67f28cdba85c362da17909c69c19952e3ef931c7`