### PR TITLE
ImOnline integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,16 @@ git = 'https://github.com/paritytech/substrate.git'
 tag = 'monthly-2021-10'
 version = '4.0.0-dev'
 
+[dependencies.sp-staking]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-10'
+version = '4.0.0-dev'
+
+[dependencies.log]
+default-features = false
+version = '0.4.14'
+
 [dependencies.codec]
 default-features = false
 features = ['derive']
@@ -61,6 +71,7 @@ version = '4.0.0-dev'
 
 [dependencies.pallet-session]
 default-features = false
+features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
 tag = 'monthly-2021-10'
 version = '4.0.0-dev'

--- a/docs/im-online-integration.md
+++ b/docs/im-online-integration.md
@@ -1,0 +1,243 @@
+# How to use the Validator Set pallet with ImOnline pallet for automatic removal of offline validators
+
+## Setup
+
+* Before following the steps below, make sure you have completed all the steps in the [readme.md](../readme.md).
+
+### Dependencies - runtime/cargo.toml
+
+* Add the `im-online` pallet in your runtime's `cargo.toml`.
+
+```toml
+[dependencies.pallet-im-online]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-10'
+version = '4.0.0-dev'
+```
+
+```toml
+std = [
+	...
+	'pallet-im-online/std',
+]
+```
+
+### Pallet Initialization - runtime/src/lib.rs
+
+* Import `ImOnlineId` and `Verify` `runtime/src/lib.rs`.
+
+```rust
+use sp_runtime::traits::{
+	AccountIdLookup, BlakeTwo256, Block as BlockT, Verify, IdentifyAccount, NumberFor, OpaqueKeys,
+};
+use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
+```
+
+* Add the `ImOnline` key to the session keys for your runtime in `runtime/src/lib.rs`:
+
+```rust
+impl_opaque_keys! {
+		pub struct SessionKeys {
+			pub aura: Aura,
+			pub grandpa: Grandpa,
+			pub im_online: ImOnline,
+		}
+	}
+```
+
+* Add the `im-online` pallet and it's configuration. This will require more types to be imported.
+
+```rust
+parameter_types! {
+	pub const ImOnlineUnsignedPriority: TransactionPriority = TransactionPriority::max_value();
+	pub const MaxKeys: u32 = 10_000;
+	pub const MaxPeerInHeartbeats: u32 = 10_000;
+	pub const MaxPeerDataEncodingSize: u32 = 1_000;
+}
+
+impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
+where
+	Call: From<LocalCall>,
+{
+	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+		call: Call,
+		public: <Signature as Verify>::Signer,
+		account: AccountId,
+		nonce: Index,
+	) -> Option<(Call, <UncheckedExtrinsic as sp_runtime::traits::Extrinsic>::SignaturePayload)> {
+		let tip = 0;
+		let period =
+			BlockHashCount::get().checked_next_power_of_two().map(|c| c / 2).unwrap_or(2) as u64;
+		let current_block = System::block_number().saturated_into::<u64>().saturating_sub(1);
+		let era = Era::mortal(period, current_block);
+		let extra = (
+			frame_system::CheckSpecVersion::<Runtime>::new(),
+			frame_system::CheckTxVersion::<Runtime>::new(),
+			frame_system::CheckGenesis::<Runtime>::new(),
+			frame_system::CheckEra::<Runtime>::from(era),
+			frame_system::CheckNonce::<Runtime>::from(nonce),
+			frame_system::CheckWeight::<Runtime>::new(),
+			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+		);
+		let raw_payload = SignedPayload::new(call, extra)
+			.map_err(|e| {
+				log::warn!("Unable to create signed payload: {:?}", e);
+			})
+			.ok()?;
+		let signature = raw_payload.using_encoded(|payload| C::sign(payload, public))?;
+		let address = account;
+		let (call, extra, _) = raw_payload.deconstruct();
+		Some((call, (sp_runtime::MultiAddress::Id(address), signature.into(), extra)))
+	}
+}
+
+impl frame_system::offchain::SigningTypes for Runtime {
+	type Public = <Signature as Verify>::Signer;
+	type Signature = Signature;
+}
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
+where
+	Call: From<C>,
+{
+	type Extrinsic = UncheckedExtrinsic;
+	type OverarchingCall = Call;
+}
+
+impl pallet_im_online::Config for Runtime {
+	type AuthorityId = ImOnlineId;
+	type Event = Event;
+	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type ValidatorSet = ValidatorSet;
+	type ReportUnresponsiveness = ValidatorSet;
+	type UnsignedPriority = ImOnlineUnsignedPriority;
+	type WeightInfo = pallet_im_online::weights::SubstrateWeight<Runtime>;
+	type MaxKeys = MaxKeys;
+	type MaxPeerInHeartbeats = MaxPeerInHeartbeats;
+	type MaxPeerDataEncodingSize = MaxPeerDataEncodingSize;
+}
+```
+
+* Add `im-online` pallet in `construct_runtime` macro.
+
+```rust
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = opaque::Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		...
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		ValidatorSet: validator_set::{Pallet, Call, Storage, Event<T>, Config<T>},
+		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
+		ImOnline: pallet_im_online::{Pallet, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
+		Aura: pallet_aura::{Pallet, Config<T>},
+		Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event},
+		...
+		...
+	}
+);
+```
+
+### Genesis config - chain_spec.rs
+
+* Add the `im-online` pallet in your node `cargo.toml`. This is needed because we need to import some types in the `chain_spec.rs`.
+
+```toml
+[dependencies.pallet-im-online]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-10'
+version = '4.0.0-dev'
+```
+
+* Import `ImOnlineId` in the `chain_spec.rs`.
+
+```rust
+use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
+```
+
+* Also import `ImOnlineConfig` in  `chain_spec.rs`.
+
+```rust
+use node_template_runtime::{
+	opaque::SessionKeys, AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
+	SessionConfig, Signature, SudoConfig, SystemConfig, ValidatorSetConfig, ImOnlineConfig,
+	WASM_BINARY,
+};
+```
+
+* Add `ImOnlineId` to the key generation functions in `chain_spec.rs`.
+
+```rust
+fn session_keys(aura: AuraId, grandpa: GrandpaId, im_online: ImOnlineId) -> SessionKeys {
+	SessionKeys { aura, grandpa, im_online }
+}
+
+pub fn authority_keys_from_seed(s: &str) -> (AccountId, AuraId, GrandpaId, ImOnlineId) {
+	(
+		get_account_id_from_seed::<sr25519::Public>(s),
+		get_from_seed::<AuraId>(s),
+		get_from_seed::<GrandpaId>(s),
+		get_from_seed::<ImOnlineId>(s),
+	)
+}
+```
+
+* Add genesis config in the `chain_spec.rs` file for the `im_online` pallet. Notice that the `ImOnlineId` has also been added to the tuple of keys, and it is also being used in the `keys` config for `session` pallet.
+
+```rust
+fn testnet_genesis(
+	wasm_binary: &[u8],
+	initial_authorities: Vec<(AccountId, AuraId, GrandpaId, ImOnlineId)>,
+	root_key: AccountId,
+	endowed_accounts: Vec<AccountId>,
+	_enable_println: bool,
+) -> GenesisConfig {
+	GenesisConfig {
+		system: SystemConfig {
+			// Add Wasm runtime to storage.
+			code: wasm_binary.to_vec(),
+			changes_trie_config: Default::default(),
+		},
+		balances: BalancesConfig {
+			// Configure endowed accounts with initial balance of 1 << 60.
+			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+		},
+		validator_set: ValidatorSetConfig {
+			initial_validators: initial_authorities.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
+		},
+		session: SessionConfig {
+			keys: initial_authorities
+				.iter()
+				.map(|x| {
+					(x.0.clone(), x.0.clone(), session_keys(x.1.clone(), x.2.clone(), x.3.clone()))
+				})
+				.collect::<Vec<_>>(),
+		},
+		aura: AuraConfig { authorities: vec![] },
+		grandpa: GrandpaConfig { authorities: vec![] },
+		im_online: ImOnlineConfig { keys: vec![] },
+		sudo: SudoConfig {
+			// Assign network admin rights.
+			key: root_key,
+		},
+	}
+}
+```
+
+### Types for Polkadot JS Apps/API
+
+When using the `ImOnline` pallet, update the Polkadot JS custom types to the following:
+
+```json
+{
+  "Keys": "SessionKeys3"
+}
+```
+
+## Run
+
+To run the node and network, follow the instructions as demonstrated in the video [here](https://www.youtube.com/watch?v=lIYxE-tOAdw).

--- a/docs/im-online-integration.md
+++ b/docs/im-online-integration.md
@@ -119,6 +119,12 @@ impl pallet_im_online::Config for Runtime {
 }
 ```
 
+* Declare the `SignedPayload` type in `runtime/src/lib.rs`.
+
+```rust
+pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
+```
+
 * Add `im-online` pallet in `construct_runtime` macro.
 
 ```rust

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ To see this pallet in action in a Substrate runtime, watch this video - https://
 
 ## Setup with Substrate Node Template
 
+### Dependencies - runtime/cargo.toml
+
 * Add the module's dependency in the `Cargo.toml` of your runtime directory. Make sure to enter the correct path or git url of the pallet as per your setup.
 
 * Make sure that you also have the Substrate [session pallet](https://github.com/paritytech/substrate/tree/master/frame/session) as part of your runtime. This is because the validator-set pallet is dependent on the session pallet.
@@ -24,7 +26,7 @@ version = '4.0.0-dev'
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-09+1'
+tag = 'monthly-2021-10'
 version = '4.0.0-dev'
 ```
 
@@ -36,11 +38,13 @@ std = [
 ]
 ```
 
+### Pallet Initialization - runtime/src/lib.rs
+
 * Import `OpaqueKeys` in your `runtime/src/lib.rs`.
 
 ```rust
 use sp_runtime::traits::{
-	AccountIdLookup, BlakeTwo256, Block as BlockT, Verify, IdentifyAccount, NumberFor, OpaqueKeys
+	AccountIdLookup, BlakeTwo256, Block as BlockT, Verify, IdentifyAccount, NumberFor, OpaqueKeys,
 };
 ```
 
@@ -53,13 +57,18 @@ use sp_runtime::traits::{
 * Declare the pallet in your `runtime/src/lib.rs`. The pallet supports configurable origin and you can either set it to use one of the governance pallets (Collective, Democracy, etc.), or just use root as shown below. But **do not use a normal origin here** because the addition and removal of validators should be done using elevated privileges.
 
 ```rust
+parameter_types! {
+	pub const MinAuthorities: u32 = 2;
+}
+
 impl validator_set::Config for Runtime {
 	type Event = Event;
 	type AddRemoveOrigin = EnsureRoot<AccountId>;
+	type MinAuthorities = MinAuthorities;
 }
 ```
 
-* Also, declare the session pallet in  your `runtime/src/lib.rs`. The type configuration of session pallet would depend on the ValidatorSet pallet as shown below.
+* Also, declare the session pallet in  your `runtime/src/lib.rs`. Some of the type configuration of session pallet would depend on the ValidatorSet pallet as shown below.
 
 ```rust
 parameter_types! {
@@ -81,7 +90,7 @@ impl pallet_session::Config for Runtime {
 }
 ```
 
-* Add both `session` and `validator_set` pallets in `construct_runtime` macro. **Make sure to add them before `Aura` and `Grandpa` pallets and after `Balances`.**
+* Add `validator_set`, and `session` pallets in `construct_runtime` macro. **Make sure to add them before `Aura` and `Grandpa` pallets and after `Balances`. Also make sure that the `validator_set` pallet is added _before_ the `session` pallet, because it provides the initial validators at genesis, and must initialize first.**
 
 ```rust
 construct_runtime!(
@@ -92,14 +101,42 @@ construct_runtime!(
 	{
 		...
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
 		ValidatorSet: validator_set::{Pallet, Call, Storage, Event<T>, Config<T>},
+		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
 		Aura: pallet_aura::{Pallet, Config<T>},
 		Grandpa: pallet_grandpa::{Pallet, Call, Storage, Config, Event},
 		...
 		...
 	}
 );
+```
+
+### Genesis config - chain_spec.rs
+
+* Import `opaque::SessionKeys, ValidatorSetConfig, SessionConfig` from the runtime in `node/src/chain_spec.rs`.
+  
+```rust
+use node_template_runtime::{
+	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
+	SudoConfig, SystemConfig, WASM_BINARY, Signature, 
+	opaque::SessionKeys, ValidatorSetConfig, SessionConfig
+};
+```
+
+* And then in `node/src/chain_spec.rs` update the key generation functions.
+
+```rust
+fn session_keys(aura: AuraId, grandpa: GrandpaId) -> SessionKeys {
+	SessionKeys { aura, grandpa }
+}
+
+pub fn authority_keys_from_seed(s: &str) -> (AccountId, AuraId, GrandpaId) {
+	(
+		get_account_id_from_seed::<sr25519::Public>(s),
+		get_from_seed::<AuraId>(s),
+		get_from_seed::<GrandpaId>(s)
+	)
+}
 ```
 
 * Add genesis config in the `chain_spec.rs` file for `session` and `validatorset` pallets, and update it for `Aura` and `Grandpa` pallets. Because the validators are provided by the `session` pallet, we do not initialize them explicitly for `Aura` and `Grandpa` pallets. Order is important, notice that `pallet_session` is declared after `pallet_balances` since it depends on it (session accounts should have some balance).
@@ -132,61 +169,27 @@ fn testnet_genesis(initial_authorities: Vec<(AccountId, AuraId, GrandpaId)>,
 }
 ```
 
-* Make sure you have the same number and order of session keys for your runtime. First in `runtime/src/lib.rs`:
-
-```rust
-pub struct SessionKeys {
-	pub aura: Aura,
-	pub grandpa: Grandpa,
-}
-```
-
-* And then in `node/src/chain_spec.rs`:
-
-```rust
-fn session_keys(
-	aura: AuraId,
-	grandpa: GrandpaId,
-) -> SessionKeys {
-	SessionKeys { aura, grandpa }
-}
-
-pub fn authority_keys_from_seed(s: &str) -> (
-	AccountId,
-	AuraId,
-	GrandpaId
-) {
-	(
-		get_account_id_from_seed::<sr25519::Public>(s),
-		get_from_seed::<AuraId>(s),
-		get_from_seed::<GrandpaId>(s)
-	)
-}
-```
-
-* Import `opaque::SessionKeys, ValidatorSetConfig, SessionConfig` from the runtime in `node/src/chain_spec.rs`.
-  
-```rust
-use node_template_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, SystemConfig, WASM_BINARY, Signature, 
-	opaque::SessionKeys, ValidatorSetConfig, SessionConfig
-};
-```
-
-## Run
-
-Once you have set up the pallet in your node/node-template and everything compiles, watch this video to see how to run the chain and add validators - https://www.youtube.com/watch?v=lIYxE-tOAdw.
-
-To use the pallet with the `Collective` pallet, follow the steps in [docs/council-integration.md](./docs/council-integration.md).
-
-## Types for Polkadot JS Apps/API
+### Types for Polkadot JS Apps/API
 
 ```json
 {
   "Keys": "SessionKeys2"
 }
 ```
+
+## Run
+
+Once you have set up the pallet in your node/node-template and everything compiles, watch this video to see how to run the chain and add validators - https://www.youtube.com/watch?v=lIYxE-tOAdw.
+
+## Extensions
+
+### Council-based governance
+
+Instead of using `sudo`, for a council-based governance, use the pallet with the `Collective` pallet. Follow the steps in [docs/council-integration.md](./docs/council-integration.md).
+
+### Auto-removal of offline validators
+
+When a validator goes offline, it skips its block production slot in Aura and that causes increased block times. Sometimes, we want to remove these offline validators so that the block time can recover to normal. The `ImOnline` pallet, when added to a runtime, can report offline validators and the `ValidatorSet` pallet implements the required types to integrate with `ImOnline` pallet for automatic removal of offline validators. To use the `ValidatorSet` pallet with the `ImOnline` pallet, follow the steps in [docs/im-online-integration.md](./docs/im-online-integration.md).
 
 ## Disclaimer
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{ensure, traits::{EstimateNextSessionRotation, Get, ValidatorSet, ValidatorSetWithIdentification}};
+use frame_support::{
+    ensure,
+    traits::{EstimateNextSessionRotation, Get, ValidatorSet, ValidatorSetWithIdentification},
+};
 pub use pallet::*;
 use sp_runtime::{
     traits::{Convert, Zero},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,6 @@ pub mod pallet {
     // Errors inform users that something went wrong.
     #[pallet::error]
     pub enum Error<T> {
-        /// No validators available.
-        NoValidators,
-
         /// Target (post-removal) validator count is below the minimum.
         TooLowValidatorCount,
     }
@@ -126,7 +123,7 @@ pub mod pallet {
         ) -> DispatchResult {
             T::AddRemoveOrigin::ensure_origin(origin)?;
 
-            Self::do_remove_validator(validator_id, true)?;
+            Self::do_remove_validator(validator_id)?;
 
             Ok(())
         }
@@ -154,18 +151,14 @@ impl<T: Config> Pallet<T> {
         Ok(validator_id)
     }
 
-    fn do_remove_validator(
-        validator_id: T::AccountId,
-        force_remove: bool,
-    ) -> Result<T::AccountId, DispatchError> {
+    fn do_remove_validator(validator_id: T::AccountId) -> Result<T::AccountId, DispatchError> {
         let mut validators = <Validators<T>>::get();
-        if !force_remove {
-            // Ensuring that the post removal, target validator count doesn't go below the minimum.
-            ensure!(
-                validators.len().saturating_sub(1) as u32 >= T::MinAuthorities::get(),
-                Error::<T>::TooLowValidatorCount
-            );
-        }
+
+        // Ensuring that the post removal, target validator count doesn't go below the minimum.
+        ensure!(
+            validators.len().saturating_sub(1) as u32 >= T::MinAuthorities::get(),
+            Error::<T>::TooLowValidatorCount
+        );
 
         validators.retain(|v| *v != validator_id);
 


### PR DESCRIPTION
When a validator goes offline, it skips its block production slot in Aura and that causes increased block times. Sometimes, we want to remove these offline validators so that the block time can recover to normal. The `ImOnline` pallet, when added to a runtime, can report offline validators and the `ValidatorSet` pallet now implements the required types to integrate with `ImOnline` pallet for automatic removal of offline validators.