### PR TITLE
Upgrade to polkadot-v0.9.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,27 +13,27 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.log]
 default-features = false
@@ -49,28 +49,31 @@ version = '3.1.2'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.pallet-session]
 default-features = false
 features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 
 [dependencies.scale-info]
 default-features = false
 features = ['derive']
 version = '2.1.1'
+
+[dependencies.syn]
+version = "=1.0.96"
 
 [features]
 default = ['std']

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators using extrinsics, in Substrate-based PoA networks.
 
-**Note: Current master is compatible with Substrate [polkadot-v0.9.22](https://github.com/paritytech/substrate/tree/polkadot-v0.9.22) branch. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate [polkadot-v0.9.23](https://github.com/paritytech/substrate/tree/polkadot-v0.9.23) branch. For older versions, please see releases/tags.**
 
 ## Demo
 
@@ -21,12 +21,12 @@ To see this pallet in action in a Substrate runtime, watch this video - https://
 default-features = false
 package = 'substrate-validator-set'
 git = 'https://github.com/gautamdhameja/substrate-validator-set.git'
-version = '0.9.22'
+version = '0.9.23'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.22'
+branch = 'polkadot-v0.9.23'
 ```
 
 ```toml


### PR DESCRIPTION
This PR upgrades the dependencies to follow Substrate's polkadot-v0.9.23 branch.

I had to lock the "syn" package version number, otherwise the project would not compile. The error comes from [here](https://github.com/paritytech/substrate/blob/polkadot-v0.9.23/frame/support/procedural/tools/src/syn_ext.rs#L50), `syn::group` is now private. This issue is fixed at least since `polkadot-v0.9.24` so the "lock" may be removed as soon was we upgrade to polkadot-v0.9.24 (I'll submit a PR in the coming weeks).