### PR TITLE
Upgrade to Polkadot v0.9.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'substrate-validator-set'
-version = '0.9.35'
+version = '0.9.37'
 authors = ['Gautam Dhameja <quasijatt@outlook.com>']
 edition = '2021'
 license = 'Apache-2.0'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,27 +13,27 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.log]
 default-features = false
@@ -49,23 +49,23 @@ version = '3.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.pallet-session]
 default-features = false
 features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.36'
 
 [dependencies.scale-info]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,27 +13,27 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.log]
 default-features = false
@@ -49,23 +49,23 @@ version = '3.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.pallet-session]
 default-features = false
 features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.36'
+branch = 'polkadot-v0.9.37'
 
 [dependencies.scale-info]
 default-features = false

--- a/docs/im-online-integration.md
+++ b/docs/im-online-integration.md
@@ -12,7 +12,7 @@
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.37'
 ```
 
 ```toml
@@ -154,7 +154,7 @@ construct_runtime!(
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.37'
 ```
 
 * Import `ImOnlineId` in the `chain_spec.rs`.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators using extrinsics in PoA networks.
 
-**Note: Current master is compatible with Substrate [polkadot-v0.9.35](https://github.com/paritytech/substrate/tree/polkadot-v0.9.35) branch. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate [polkadot-v0.9.37](https://github.com/paritytech/substrate/tree/polkadot-v0.9.37) branch. For older versions, please see releases/tags.**
 
 ## Demo
 
@@ -21,12 +21,12 @@ To see this pallet in action in a Substrate runtime, watch this video - https://
 default-features = false
 package = 'substrate-validator-set'
 git = 'https://github.com/gautamdhameja/substrate-validator-set.git'
-version = '0.9.33'
+version = '0.9.37'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.35'
+branch = 'polkadot-v0.9.37'
 ```
 
 ```toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub mod pallet {
 		///
 		/// The origin can be configured using the `AddRemoveOrigin` type in the
 		/// host runtime. Can also be set to sudo/root.
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn add_validator(origin: OriginFor<T>, validator_id: T::AccountId) -> DispatchResult {
 			T::AddRemoveOrigin::ensure_origin(origin)?;
@@ -134,6 +135,7 @@ pub mod pallet {
 		///
 		/// The origin can be configured using the `AddRemoveOrigin` type in the
 		/// host runtime. Can also be set to sudo/root.
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn remove_validator(
 			origin: OriginFor<T>,
@@ -150,6 +152,7 @@ pub mod pallet {
 		/// Add an approved validator again when it comes back online.
 		///
 		/// For this call, the dispatch origin must be the validator itself.
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		pub fn add_validator_again(
 			origin: OriginFor<T>,


### PR DESCRIPTION
* Upgrade to Polkadot v0.9.36: 
The attribute `pallet::call_index` is added as recommended, see those PRs on substrate: [11381](https://github.com/paritytech/substrate/pull/11381) and [12891](https://github.com/paritytech/substrate/pull/12891).
* Upgrade to Polkadot v0.9.37.