### PR TITLE
Do actually unapprove validator.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,10 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(who == validator_id, Error::<T>::BadOrigin);
-			ensure!(<ApprovedValidators<T>>::get().contains(&validator_id), Error::<T>::ValidatorNotApproved);
+			ensure!(
+				<ApprovedValidators<T>>::get().contains(&validator_id),
+				Error::<T>::ValidatorNotApproved
+			);
 
 			Self::do_add_validator(validator_id)?;
 
@@ -171,7 +174,10 @@ pub mod pallet {
 
 impl<T: Config> Pallet<T> {
 	fn initialize_validators(validators: &[T::AccountId]) {
-		assert!(validators.len() as u32 >= T::MinAuthorities::get(), "Initial set of validators must be at least T::MinAuthorities");
+		assert!(
+			validators.len() as u32 >= T::MinAuthorities::get(),
+			"Initial set of validators must be at least T::MinAuthorities"
+		);
 		assert!(<Validators<T>>::get().is_empty(), "Validators are already initialized!");
 
 		<Validators<T>>::put(validators);
@@ -217,6 +223,7 @@ impl<T: Config> Pallet<T> {
 	fn unapprove_validator(validator_id: T::AccountId) -> DispatchResult {
 		let mut approved_set = <ApprovedValidators<T>>::get();
 		approved_set.retain(|v| *v != validator_id);
+		<ApprovedValidators<T>>::set(approved_set);
 		Ok(())
 	}
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,14 +28,22 @@ fn add_validator_updates_validators_list() {
 fn remove_validator_updates_validators_list() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(ValidatorSet::remove_validator(RuntimeOrigin::root(), 2));
-		assert_eq!(ValidatorSet::validators(), vec![1u64, 3u64]);
+		assert_eq!(ValidatorSet::validators(), &[1, 3]);
+		assert_eq!(ValidatorSet::approved_validators(), &[1, 3]);
+		// add validator again
+		assert_ok!(ValidatorSet::add_validator(RuntimeOrigin::root(), 2));
+		assert_eq!(ValidatorSet::validators(), &[1, 3, 2]);
+		assert_eq!(ValidatorSet::approved_validators(), &[1, 3, 2]);
 	});
 }
 
 #[test]
 fn add_validator_fails_with_invalid_origin() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(ValidatorSet::add_validator(RuntimeOrigin::signed(1), 4), DispatchError::BadOrigin);
+		assert_noop!(
+			ValidatorSet::add_validator(RuntimeOrigin::signed(1), 4),
+			DispatchError::BadOrigin
+		);
 	});
 }
 
@@ -54,6 +62,9 @@ fn duplicate_check() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(ValidatorSet::add_validator(RuntimeOrigin::root(), 4));
 		assert_eq!(ValidatorSet::validators(), vec![1u64, 2u64, 3u64, 4u64]);
-		assert_noop!(ValidatorSet::add_validator(RuntimeOrigin::root(), 4), Error::<Test>::Duplicate);
+		assert_noop!(
+			ValidatorSet::add_validator(RuntimeOrigin::root(), 4),
+			Error::<Test>::Duplicate
+		);
 	});
 }


### PR DESCRIPTION
## Description
I think the intended behavior of `unapprove_validator` is to actually remove an account from the `ApprovedValidators` vector. However, a line was missing where the modified `approved_set` is actually written to storage. Therefore, after removing a validator via `remove_validator` using the sudo account, I couldn't add the same account again using `add_validator` because of a `Duplicate` error thrown by `approve_validator` which was understandable, as the `remove_validator` call didn't actually remove the validator from `ApprovedValidators`.

Let me know if I'm missing something and this was intended.

## Solution
- Added a line in `src/lib.rs` to `unapprove_validator` that wrote the modified `approved_set` to storage.
- Extended the `remove_validator_updates_validators_list` test with logic that would've caught this issue.

PS. I ran `cargo fmt` out of habit and it applied some fmt changes to the code  but I can remove those if needed.