### PR TITLE
Upgrade to Polkadot v0.9.40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'substrate-validator-set'
-version = '0.9.39'
+version = '0.9.40'
 authors = ['Gautam Dhameja <quasijatt@outlook.com>']
 edition = '2021'
 license = 'Apache-2.0'
@@ -13,27 +13,27 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.log]
 default-features = false
@@ -49,23 +49,23 @@ version = '3.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.pallet-session]
 default-features = false
 features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 
 [dependencies.scale-info]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'substrate-validator-set'
-version = '0.9.37'
+version = '0.9.39'
 authors = ['Gautam Dhameja <quasijatt@outlook.com>']
 edition = '2021'
 license = 'Apache-2.0'
@@ -13,27 +13,27 @@ version = '1.0.126'
 [dependencies.sp-core]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.sp-io]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.sp-runtime]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.log]
 default-features = false
@@ -49,23 +49,23 @@ version = '3.0.0'
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 optional = true
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.frame-support]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.frame-system]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.pallet-session]
 default-features = false
 features = ['historical']
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 
 [dependencies.scale-info]
 default-features = false

--- a/docs/im-online-integration.md
+++ b/docs/im-online-integration.md
@@ -12,7 +12,7 @@
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 ```
 
 ```toml
@@ -154,7 +154,7 @@ construct_runtime!(
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 ```
 
 * Import `ImOnlineId` in the `chain_spec.rs`.

--- a/docs/im-online-integration.md
+++ b/docs/im-online-integration.md
@@ -12,7 +12,7 @@
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 ```
 
 ```toml
@@ -154,7 +154,7 @@ construct_runtime!(
 [dependencies.pallet-im-online]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 ```
 
 * Import `ImOnlineId` in the `chain_spec.rs`.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators in PoA networks.
 
-**Note: Current master is compatible with Substrate [polkadot-v0.9.37](https://github.com/paritytech/substrate/tree/polkadot-v0.9.37) branch. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate [polkadot-v0.9.39](https://github.com/paritytech/substrate/tree/polkadot-v0.9.39) branch. For older versions, please see releases/tags.**
 
 ## Demo
 
@@ -21,12 +21,12 @@ To see this pallet in action in a Substrate runtime, watch this video - https://
 default-features = false
 package = 'substrate-validator-set'
 git = 'https://github.com/gautamdhameja/substrate-validator-set.git'
-version = '0.9.37'
+version = '0.9.39'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.37'
+branch = 'polkadot-v0.9.39'
 ```
 
 ```toml

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A [Substrate](https://github.com/paritytech/substrate/) pallet to add/remove authorities/validators in PoA networks.
 
-**Note: Current master is compatible with Substrate [polkadot-v0.9.39](https://github.com/paritytech/substrate/tree/polkadot-v0.9.39) branch. For older versions, please see releases/tags.**
+**Note: Current master is compatible with Substrate [polkadot-v0.9.40](https://github.com/paritytech/substrate/tree/polkadot-v0.9.40) branch. For older versions, please see releases/tags.**
 
 ## Demo
 
@@ -21,12 +21,12 @@ To see this pallet in action in a Substrate runtime, watch this video - https://
 default-features = false
 package = 'substrate-validator-set'
 git = 'https://github.com/gautamdhameja/substrate-validator-set.git'
-version = '0.9.39'
+version = '0.9.40'
 
 [dependencies.pallet-session]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-branch = 'polkadot-v0.9.39'
+branch = 'polkadot-v0.9.40'
 ```
 
 ```toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -147,7 +147,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
-		frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_ref_time(1024));
+		frame_system::limits::BlockWeights::simple_max(frame_support::weights::Weight::from_parts(1024, 0));
 }
 
 impl frame_system::Config for Test {


### PR DESCRIPTION
* Upgrade to [polkadot-v0.9.40](https://github.com/paritytech/polkadot/releases/tag/v0.9.40)
* Remove useless `trait Store` - see https://github.com/paritytech/substrate/pull/13535
* Change deprecated `Weight::from_ref_time(n)` into `Weight::from_parts(n, 0)`.